### PR TITLE
Bump Bevy version to 0.12 and remove infinite grid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ authors = ["Caio Piccirillo <caiopiccirillo@gmail.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.11.3"
-bevy_panorbit_camera = "0.8.0"
-bevy_rapier3d = { version = "0.22.0", features = [ "simd-stable", "wasm-bindgen" ] } # "debug-render-3d
-bevy-inspector-egui = "0.20.0" 
-bevy_infinite_grid = { git = "https://github.com/ForesightMiningSoftwareCorporation/bevy_infinite_grid", branch = "main" }
+bevy = "0.12.1"
+bevy_panorbit_camera = "0.9.2"
+bevy_rapier3d = { version = "0.23.0", features = [ "simd-stable", "wasm-bindgen" ] } # "debug-render-3d
+bevy-inspector-egui = "0.21.0" 
+# bevy_infinite_grid = { git = "https://github.com/ForesightMiningSoftwareCorporation/bevy_infinite_grid", branch = "main" }
 
 # Enable a small amount of optimization in debug mode
 [profile.dev]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 //! In case of multiple scenes, you can select which to display by adapting the file path: `/path/to/model.gltf#Scene1`.
 //! With no arguments it will load the `rotary_pendulum` glTF model from the repository assets subdirectory.
 
-use bevy::{asset::ChangeWatcher, prelude::*, utils::Duration, window::WindowPlugin};
+use bevy::{prelude::*, window::WindowPlugin};
 
 #[cfg(feature = "blender")]
 use bevy::{
@@ -13,7 +13,7 @@ use bevy::{
     render::primitives::{Aabb, Sphere},
 };
 
-use bevy_infinite_grid::{InfiniteGrid, InfiniteGridBundle, InfiniteGridPlugin};
+// use bevy_infinite_grid::{InfiniteGrid, InfiniteGridBundle, InfiniteGridPlugin};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier3d::prelude::*;
 #[cfg(feature = "embedded-model")]
@@ -43,9 +43,8 @@ fn main() {
                 ..default()
             })
             .set(AssetPlugin {
-                asset_folder: std::env::var("CARGO_MANIFEST_DIR")
-                    .unwrap_or_else(|_| ".".to_string()),
-                watch_for_changes: ChangeWatcher::with_delay(Duration::from_millis(200)),
+                file_path: std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()),
+                ..default()
             }),
         PanOrbitCameraPlugin,
         #[cfg(feature = "blender")]
@@ -55,7 +54,7 @@ fn main() {
         WorldInspectorPlugin::new(),
         RapierPhysicsPlugin::<NoUserData>::default(),
         RapierDebugRenderPlugin::default(),
-        InfiniteGridPlugin,
+        // InfiniteGridPlugin,
     ))
     .add_systems(Startup, setup);
 
@@ -103,13 +102,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 .load("assets/environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
         },
     ));
-    commands.spawn(InfiniteGridBundle {
-        grid: InfiniteGrid {
-            // shadow_color: None,
-            // ..default()
-        },
-        ..default()
-    });
+    // commands.spawn(InfiniteGridBundle {
+    //     grid: InfiniteGrid {
+    //         // shadow_color: None,
+    //         // ..default()
+    //     },
+    //     ..default()
+    // });
 }
 
 #[cfg(feature = "blender")]


### PR DESCRIPTION
This PR supersede https://github.com/Open-Source-Digital-Twin/motion-control-playground/pull/35, https://github.com/Open-Source-Digital-Twin/motion-control-playground/pull/34, https://github.com/Open-Source-Digital-Twin/motion-control-playground/pull/33 and https://github.com/Open-Source-Digital-Twin/motion-control-playground/pull/32.
Also, the [Infinite grid](https://github.com/ForesightMiningSoftwareCorporation/bevy_infinite_grid) was removed due to lack of support to Bevy 0.12. Once this plugin has support to this Bevy version, the code will be updated.